### PR TITLE
feat(generate-examples-index): add okay/fail to stdout

### DIFF
--- a/src/generate-examples-index/content-builder/builder.ts
+++ b/src/generate-examples-index/content-builder/builder.ts
@@ -150,12 +150,12 @@ export class ContentBuilder {
                   }
 
                   ++finished;
-                  console.info(
-                    `${("" + Math.floor((finished / total) * 100)).padStart(
-                      3,
-                      " "
-                    )}% - ${example.path}`
-                  );
+
+                  const percentage = (
+                    Math.floor((finished / total) * 100) + "%"
+                  ).padStart(3, " ");
+                  const validText = valid ? "okay" : "fail";
+                  console.info(`${percentage} ${validText} - ${example.path}`);
                 }
               }
             )


### PR DESCRIPTION
This adds okay to each screenshot that passes the test and fail to each that doesn't. This is handy especially in CI as it's easy to read the stdout but pretty difficult to get the screenshots from there.

### Before
```
 93% - examples/network/data/scalingCustom.html
 95% - examples/network/basic_usage/standalone.html
 96% - examples/network/basic_usage/peer.html
 97% - examples/network/basic_usage/legacy.html
 98% - examples/network/basicUsage.html
100% - examples/network/exampleApplications/worldCupPerformance.html
Screenshot files for 80 written (80 files).

Verification: Only 79 passed (99 %), 1 failed.
This is not within the threshold set by --verify. Exiting with an error.
```
### After
```
 93% okay - examples/network/data/scalingCustom.html
 95% okay - examples/network/basic_usage/standalone.html
 96% fail - examples/network/basic_usage/peer.html
 97% okay - examples/network/basic_usage/legacy.html
 98% okay - examples/network/basicUsage.html
100% okay - examples/network/exampleApplications/worldCupPerformance.html
Screenshot files for 80 written (80 files).

Verification: Only 79 passed (99 %), 1 failed.
This is not within the threshold set by --verify. Exiting with an error.
```