### PR TITLE
fix(rollup): use browser versions if available

### DIFF
--- a/src/module/generate-rollup-configuration/index.ts
+++ b/src/module/generate-rollup-configuration/index.ts
@@ -235,6 +235,7 @@ const generateRollupPluginArray = (
       ]
     }),
     nodeResolvePlugin({
+      browser: true,
       extensions: [".js", ".json", ".ts"],
       mainFields: ["jsnext", "module", "main"]
     }),


### PR DESCRIPTION
We've never had combined node.js/browser dependencies so this was never a problem but as per visjs/vis-timeline#328 we'll need this fix from now on.