### PR TITLE
Remove sourcemaps to reduce size of distribution

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -61,13 +61,13 @@ export default [
         banner: bannerModule,
         file: `dist/vis-dev-utils.cjs.js`,
         format: "cjs",
-        sourcemap: true
+        sourcemap: false
       },
       {
         banner: bannerModule,
         file: `dist/vis-dev-utils.esm.js`,
         format: "esm",
-        sourcemap: true
+        sourcemap: false
       }
     ],
     external,
@@ -81,7 +81,7 @@ export default [
         banner: bannerCommand,
         file: `${name}/index.js`,
         format: "cjs",
-        sourcemap: true
+        sourcemap: false
       },
       external,
       plugins: getPlugins()
@@ -95,7 +95,7 @@ export default [
         banner: bannerCommand,
         file: `bin/${name}.js`,
         format: "cjs",
-        sourcemap: true
+        sourcemap: false
       },
       external,
       plugins: getPlugins()


### PR DESCRIPTION
See ticket https://github.com/visjs/vis-timeline/issues/410