### PR TITLE
fix(rollup-conf): styles dir location

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "rollup-plugin-analyzer": "^3.2.0",
     "rollup-plugin-babel": "^4.3.0",
     "rollup-plugin-copy": "^3.3.0",
-    "rollup-plugin-postcss": "^2.0.0 || ^3.0.0",
+    "rollup-plugin-postcss": "^3.0.0",
     "rollup-plugin-terser": "^5.2.0",
     "rollup-plugin-typescript2": "^0.24.0 || ^0.26.0 || ^0.27.0"
   },

--- a/src/module/generate-rollup-configuration/index.ts
+++ b/src/module/generate-rollup-configuration/index.ts
@@ -529,12 +529,14 @@ export function generateRollupConfiguration(
 
   const commonOutputESM = {
     banner,
+    dir: ".",
     format: "esm",
     globals: processGlobals(globals),
     sourcemap: true
   };
   const commonOutputUMD = {
     banner,
+    dir: ".",
     exports: "named",
     extend: true,
     format: "umd",
@@ -555,8 +557,14 @@ export function generateRollupConfiguration(
       external: external.standalone,
       input: standaloneEntry,
       output: [
-        { ...commonOutputESM, file: `standalone/esm/${libraryFilename}.js` },
-        { ...commonOutputUMD, file: `standalone/umd/${libraryFilename}.js` }
+        {
+          ...commonOutputESM,
+          entryFileNames: `standalone/esm/${libraryFilename}.js`
+        },
+        {
+          ...commonOutputUMD,
+          entryFileNames: `standalone/umd/${libraryFilename}.js`
+        }
       ],
       plugins: getPlugins("standalone", {
         injectCSS,
@@ -570,9 +578,12 @@ export function generateRollupConfiguration(
       output: [
         {
           ...commonOutputESM,
-          file: `standalone/esm/${libraryFilename}.min.js`
+          entryFileNames: `standalone/esm/${libraryFilename}.min.js`
         },
-        { ...commonOutputUMD, file: `standalone/umd/${libraryFilename}.min.js` }
+        {
+          ...commonOutputUMD,
+          entryFileNames: `standalone/umd/${libraryFilename}.min.js`
+        }
       ],
       plugins: getPlugins("standalone", {
         injectCSS,
@@ -588,12 +599,12 @@ export function generateRollupConfiguration(
       output: [
         {
           ...commonOutputESM,
-          file: `peer/esm/${libraryFilename}.js`,
+          entryFileNames: `peer/esm/${libraryFilename}.js`,
           paths: getPaths("peer")
         },
         {
           ...commonOutputUMD,
-          file: `peer/umd/${libraryFilename}.js`,
+          entryFileNames: `peer/umd/${libraryFilename}.js`,
           paths: getPaths("peer")
         }
       ],
@@ -608,12 +619,12 @@ export function generateRollupConfiguration(
       output: [
         {
           ...commonOutputESM,
-          file: `peer/esm/${libraryFilename}.min.js`,
+          entryFileNames: `peer/esm/${libraryFilename}.min.js`,
           paths: getPaths("peer")
         },
         {
           ...commonOutputUMD,
-          file: `peer/umd/${libraryFilename}.min.js`,
+          entryFileNames: `peer/umd/${libraryFilename}.min.js`,
           paths: getPaths("peer")
         }
       ],
@@ -630,12 +641,12 @@ export function generateRollupConfiguration(
       output: [
         {
           ...commonOutputESM,
-          file: `esnext/esm/${libraryFilename}.js`,
+          entryFileNames: `esnext/esm/${libraryFilename}.js`,
           paths: getPaths("esnext")
         },
         {
           ...commonOutputUMD,
-          file: `esnext/umd/${libraryFilename}.js`,
+          entryFileNames: `esnext/umd/${libraryFilename}.js`,
           paths: getPaths("esnext")
         }
       ],
@@ -649,12 +660,12 @@ export function generateRollupConfiguration(
       output: [
         {
           ...commonOutputESM,
-          file: `esnext/esm/${libraryFilename}.min.js`,
+          entryFileNames: `esnext/esm/${libraryFilename}.min.js`,
           paths: getPaths("esnext")
         },
         {
           ...commonOutputUMD,
-          file: `esnext/umd/${libraryFilename}.min.js`,
+          entryFileNames: `esnext/umd/${libraryFilename}.min.js`,
           paths: getPaths("esnext")
         }
       ],


### PR DESCRIPTION
Due to recent breaking changes in Rollup PostCSS plugin that I completely missed the styles dir has moved from the root to the bundle files and is now 4 times in the packages (4 copies of the same thing). This is not how it is documented and was never announced to the public as a breaking change. This commit reverses it to the way it used to be prior to the update. It also officially drops support for Rollup PostCSS plugin (dev dep in our projects) version 2 since the way paths are interpreted is different from the up to date version 3.