### PR TITLE
fix(gen-rollup-conf): disable objectHashIgnoreUnknownHack

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,7 +41,6 @@ const getPlugins = () => [
   }),
   json(),
   typescript({
-    objectHashIgnoreUnknownHack: true,
     tsconfig: "tsconfig.json"
   }),
   commonjs(),

--- a/src/module/generate-rollup-configuration/index.ts
+++ b/src/module/generate-rollup-configuration/index.ts
@@ -252,7 +252,6 @@ const generateRollupPluginArray = (
     ...(typescript
       ? [
           typescriptPlugin({
-            objectHashIgnoreUnknownHack: true,
             tsconfig
           })
         ]


### PR DESCRIPTION
This was a workaround for some issues around async function, but it seems that it's no longer needed.