### PR TITLE
fix(gen-rollup-conf): disable strict mode

### DIFF
--- a/src/module/generate-rollup-configuration/index.ts
+++ b/src/module/generate-rollup-configuration/index.ts
@@ -541,7 +541,8 @@ export function generateRollupConfiguration(
     format: "umd",
     globals: processGlobals(globals),
     name: "vis",
-    sourcemap: true
+    sourcemap: true,
+    strict: false // Regenerator runtime causes issues with CSP in strict mode.
   };
 
   const getPlugins = generateRollupPluginArray.bind(


### PR DESCRIPTION
Regenerator runtime causes issues with CSP when used in strict mode. Once we drop IE11 support we should be able to ditch regenerator runtime and reenable strict mode.

Closes #141.