### PR TITLE
fix(gen-rollup-conf): don't create CSS maps for standalone

### DIFF
--- a/src/module/generate-rollup-configuration/index.ts
+++ b/src/module/generate-rollup-configuration/index.ts
@@ -265,7 +265,8 @@ const generateRollupPluginArray = (
       extract: !injectCSS && `styles/${fullLibraryFilename}.css`,
       inject: injectCSS,
       minimize,
-      sourceMap: true,
+      // Prevent the sourcemaps from being injected into JS files.
+      sourceMap: !injectCSS,
       plugins: [
         postcssAssetsPlugin({
           loadPaths: [assets]


### PR DESCRIPTION
The CSS is injected into JS with the sourcemaps. This bloats the files without much of a benefit (they would be very rarly used, most people won't use them at all).

Saves about 50 KiB (~10%) from minified Vis Timeline.

Sourcemaps are still generated for CSS files as they're external with very little added to the CSS file itself.

Closes #104 (that tried to disable source maps for development utils, not for final consumer files).