### PR TITLE
fix(gen-rollup-conf): bypass index files in bundled JS

### DIFF
--- a/src/module/generate-rollup-configuration/index.ts
+++ b/src/module/generate-rollup-configuration/index.ts
@@ -165,20 +165,41 @@ const validate: (
 /**
  * Transform ESNext import paths to match the build version being constructed.
  *
- * @param variant - ESNext or peer build. This is not available for standalone
- * as only peer and ESNext have imports.
+ * @param buildVariant - ESNext or peer build. This is not available for
+ * standalone as only peer and ESNext have imports.
+ * @param moduleFormat - What kind of module system to use.
  *
  * @returns Path overrides for Rollup.
  */
-const getPaths = (variant: "esnext" | "peer"): Record<string, string> => ({
-  "vis-charts/esnext": `vis-charts/${variant}`,
-  "vis-data/esnext": `vis-data/${variant}`,
-  "vis-graph3d/esnext": `vis-graph3d/${variant}`,
-  "vis-network/esnext": `vis-network/${variant}`,
-  "vis-timeline/esnext": `vis-timeline/${variant}`,
-  "vis-util/esnext": `vis-util/${variant}`,
-  "vis-uuid/esnext": `vis-uuid/${variant}`
-});
+function getPaths(
+  buildVariant: "esnext" | "peer",
+  moduleFormat: "esm" | "umd"
+): Record<string, string> {
+  function getPath(
+    lib:
+      | "charts"
+      | "data"
+      | "graph3d"
+      | "network"
+      | "timeline"
+      | "util"
+      | "uuid"
+  ): Record<string, string> {
+    return {
+      [`vis-${lib}/esnext`]: `vis-${lib}/${buildVariant}/${moduleFormat}/vis-${lib}.js`
+    };
+  }
+
+  return {
+    ...getPath("charts"),
+    ...getPath("data"),
+    ...getPath("graph3d"),
+    ...getPath("network"),
+    ...getPath("timeline"),
+    ...getPath("util"),
+    ...getPath("uuid")
+  };
+}
 
 const injectCSS = true;
 const minimize = true;
@@ -601,12 +622,12 @@ export function generateRollupConfiguration(
         {
           ...commonOutputESM,
           entryFileNames: `peer/esm/${libraryFilename}.js`,
-          paths: getPaths("peer")
+          paths: getPaths("peer", "esm")
         },
         {
           ...commonOutputUMD,
           entryFileNames: `peer/umd/${libraryFilename}.js`,
-          paths: getPaths("peer")
+          paths: getPaths("peer", "umd")
         }
       ],
       plugins: getPlugins("peer", {
@@ -621,12 +642,12 @@ export function generateRollupConfiguration(
         {
           ...commonOutputESM,
           entryFileNames: `peer/esm/${libraryFilename}.min.js`,
-          paths: getPaths("peer")
+          paths: getPaths("peer", "esm")
         },
         {
           ...commonOutputUMD,
           entryFileNames: `peer/umd/${libraryFilename}.min.js`,
-          paths: getPaths("peer")
+          paths: getPaths("peer", "umd")
         }
       ],
       plugins: getPlugins("peer", {
@@ -643,12 +664,12 @@ export function generateRollupConfiguration(
         {
           ...commonOutputESM,
           entryFileNames: `esnext/esm/${libraryFilename}.js`,
-          paths: getPaths("esnext")
+          paths: getPaths("esnext", "esm")
         },
         {
           ...commonOutputUMD,
           entryFileNames: `esnext/umd/${libraryFilename}.js`,
-          paths: getPaths("esnext")
+          paths: getPaths("esnext", "umd")
         }
       ],
       plugins: getPlugins("esnext", {
@@ -662,12 +683,12 @@ export function generateRollupConfiguration(
         {
           ...commonOutputESM,
           entryFileNames: `esnext/esm/${libraryFilename}.min.js`,
-          paths: getPaths("esnext")
+          paths: getPaths("esnext", "esm")
         },
         {
           ...commonOutputUMD,
           entryFileNames: `esnext/umd/${libraryFilename}.min.js`,
-          paths: getPaths("esnext")
+          paths: getPaths("esnext", "umd")
         }
       ],
       plugins: getPlugins("esnext", {


### PR DESCRIPTION
This skips index files traversal in bundled files and requires the final file directly.

## Theoretically

### Before
```
vis-network > vis-data/esnext/esm > vis-data/esnext/esm/vis-data.js
```
This leads to the following module systems being used:
```
ESM > ESM > ESM
```
And there's absolutely nothing wrong with that.

The problem comes with UMD:
```
vis-network > vis-data/esnext/umd > vis-data/esnext/esm/vis-data.js
```
This leads to the following module systems being used:
```
UMD > ESM > UMD
```
The consequence of this may be issues like https://github.com/visjs/vis-network/issues/688. To put it shortly tools which can't handle ESM import UMD but then are told to import ESM anyway and crash.

### After
The middle step is removed which leads to: `ESM > ESM` or `UMD > UMD` which should work without problems.

## Caveats
I don't have any MWE reproducing the issues so even though this makes perfect sense and is definitely a thing that should be fixed I can't verify it will actually help anybody.