### PR TITLE
fix(gen-rollup-conf): remove obsolete workaround

### DIFF
--- a/src/module/generate-rollup-configuration/index.ts
+++ b/src/module/generate-rollup-configuration/index.ts
@@ -277,11 +277,7 @@ const generateRollupPluginArray = (
           })
         ]
       : []),
-    commonjsPlugin({
-      namedExports: {
-        timsort: ["sort"]
-      }
-    }),
+    commonjsPlugin(),
     postcssPlugin({
       extract: !injectCSS && `styles/${fullLibraryFilename}.css`,
       inject: injectCSS,


### PR DESCRIPTION
The autodetection works reliably now and the workaround was actually removed from recent releases.