### PR TITLE
fix(babel): take DOS paths into account in ignore RE

### DIFF
--- a/src/module/constants.ts
+++ b/src/module/constants.ts
@@ -1,3 +1,3 @@
 export const BABEL_IGNORE_RE = Object.freeze(
-  /\/node_modules\/(?!.*\/esnext\/)/
+  /[\\\/]node_modules[\\\/](?!.*[\\\/]esnext[\\\/])/
 );


### PR DESCRIPTION
This makes the ignore pattern, which among other things prevents the polyfilling of polyfills, work with DOS and mixed DOS-POSIX paths.

Windows supports both POSIX and DOS paths. This leads to weird situations when paths are sometimes DOS, sometimes POSIX and sometimes a combination of both. It's very chaotic and unpredictable, hence the same regexp working fine in other projects but failing in Vis Network.

Seems to fix https://github.com/visjs/vis-network/issues/699, though I'm not 100% sure there's nothing else.