### PR TITLE
fix(inspect-npm-pack): fix dry run and improve error logging

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,7 +26,10 @@ module.exports = {
     "no-unreachable": "error",
     "no-useless-escape": "off",
 
-    "no-console": ["error", { allow: ["info", "warn", "error"] }],
+    "no-console": [
+      "error",
+      { allow: ["error", "group", "groupEnd", "info", "warn"] }
+    ],
 
     "valid-jsdoc": [
       "error",

--- a/src/module/inspect-npm-pack.ts
+++ b/src/module/inspect-npm-pack.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "child_process";
 
 function runNpmPack(): string[] {
-  const result = spawnSync("npm", ["pack", "--dry-run-a"], {
+  const result = spawnSync("npm", ["pack", "--dry-run"], {
     env: { ...process.env, LC_ALL: "C" },
     stdio: "pipe",
     encoding: "utf-8"

--- a/src/module/inspect-npm-pack.ts
+++ b/src/module/inspect-npm-pack.ts
@@ -1,11 +1,31 @@
 import { spawnSync } from "child_process";
 
+function logStderr(
+  textOrLines: string | readonly string[],
+  message: string
+): never {
+  console.group('"npm pack" output');
+  console.error(
+    Array.isArray(textOrLines) ? textOrLines.join("\n") : textOrLines
+  );
+  console.groupEnd();
+
+  throw new Error(message);
+}
+
 function runNpmPack(): string[] {
   const result = spawnSync("npm", ["pack", "--dry-run"], {
     env: { ...process.env, LC_ALL: "C" },
     stdio: "pipe",
     encoding: "utf-8"
   });
+
+  if (result.status !== 0) {
+    logStderr(
+      result.stderr,
+      'Command "npm pack" exited with ${result.status}.'
+    );
+  }
 
   return result.stderr.split(/[\r\n]+/);
 }
@@ -15,6 +35,13 @@ function extractFiles(lines: string[]): string[] {
     "npm notice === Tarball Contents === "
   );
   const fileListingEnd = lines.indexOf("npm notice === Tarball Details === ");
+
+  if (fileListingStart === -1 || fileListingEnd === -1) {
+    logStderr(
+      lines.join("\n"),
+      'Couldn\'t find tarball contents in "npm pack" output.'
+    );
+  }
 
   const files = lines
     .slice(fileListingStart + 1, fileListingEnd)
@@ -30,6 +57,10 @@ function extractFiles(lines: string[]): string[] {
     .sort()
     .map(line => line.replace(/^(.*)(.{7})$/, "$2 $1"));
 
+  if (files.length === 0) {
+    logStderr(lines, 'No files found in "npm pack" output.');
+  }
+
   return files;
 }
 
@@ -39,7 +70,10 @@ function extractName(lines: string[]): string {
   );
 
   if (nameLine == null) {
-    throw new Error("Can't find the name of the package.");
+    logStderr(
+      lines,
+      'Can\'t find the name of the package in "npm pack" output.'
+    );
   }
 
   return nameLine.replace(/^npm notice name: */, "");


### PR DESCRIPTION
Fix typo in `--dry-run` argument and provide more detailed info when something fails.