### PR TITLE
fix(babel): rewrite Browserlist query

### DIFF
--- a/babel-preset/index.js
+++ b/babel-preset/index.js
@@ -6,8 +6,8 @@ module.exports = function (_context, { css = false, ts = false } = {}) {
         {
           targets: {
             // A browser is polyfilled if it is supported by it's maintainers
-            // or if it is used by at least one in every thousand of users.
-            browsers: "> 0.1% or not dead",
+            // and if it is used by at least one in every thousand of users.
+            browsers: "> 0.1% and not dead",
             // This forces Babel to polyfill ESM as if it was UMD. The reason
             // behind this is that that Babel doesn't include IE 11 polyfills
             // in ESM builds since IE 11 can't even load them. However many of


### PR DESCRIPTION
Due to a weird quirk in the syntax of Browserlist both `or not dead` and `and not dead` are intersections with the previos part of the query. Using `or` here is very confusing as it implies that we support browsers that match one (>1% usage) or the other (not dead) but in fact they have to match both. It definitely confused me (the comment above the query is a proof of it).

This changes nothing regarding the browsers we support as in this case `(A && !B) === (A || !B)` so the list of supported and polyfilled browsers stays exactly the same. It can be verified by comparing [> 0.1% or not dead](https://browserl.ist/?q=%3E+0.1%25+or+not+dead) with [> 0.1% and not dead](https://browserl.ist/?q=%3E+0.1%25+and+not+dead).