### PR TITLE
fix(generate-examples): some minor improvements

### DIFF
--- a/src/generate-examples-index/index.ts
+++ b/src/generate-examples-index/index.ts
@@ -342,7 +342,8 @@ function lintExample(path: string, page: CheerioStatic): boolean {
     }
   }
 
-  process.exit(code);
+  process.exitCode = code;
 })().catch((error): void => {
+  process.exitCode = 1;
   console.error(error);
 });

--- a/test/generate-examples-index/basic.test.ts
+++ b/test/generate-examples-index/basic.test.ts
@@ -68,7 +68,7 @@ function generate(options: {
         ["--verify", verify],
       ].flat(),
     ],
-    { stdio: "ignore" }
+    { stdio: "pipe" }
   );
 }
 
@@ -82,15 +82,17 @@ describe("generate-examples-index", function (): void {
 
   describe("working examples", function (): void {
     const output = prepareWorkplace();
-    let $index: CheerioStatic;
 
     it("generate index", function (): void {
       this.timeout(30 * 60 * 1000);
 
-      generate({ output, type: "okay" });
+      const ret = generate({ output, type: "okay" });
+      expect(ret).to.haveOwnProperty("status").that.equals(0);
     });
 
     describe("verify index", function (): void {
+      let $index: CheerioStatic;
+
       it("valid HTML", function (): void {
         $index = $.load(
           readFileSync(join(output.index, "index.html"), "utf-8")


### PR DESCRIPTION
Command:
- don't call process.exit (this forces the process to stop possibly before stderr is flushed, losing some console output), set the nonzero exit code and let the script finish normally

Test:
- print the execution output (prior to this the test case would fail with no output for debugging)
- check that generating returns with 0 status code