### PR TITLE
perf(interop): parallelize and accept tarballs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,12 +94,15 @@ jobs:
 
       - install-deps-for-screenshot-taking
 
+      - run: npm pack
+
       - run:
           command: npm run test:interop
-          # One of the examples in Vis Network sports really massive network
-          # that takes long to render and would regularly exceed the default
-          # timeout of 10 minues.
-          no_output_timeout: 20m
+          # This runs multiple things in parallel and only reports start and end
+          # of individual commands, the full logs are printed at the end. Due to
+          # this it's quite likely to go a long time without any output and
+          # still finish successfully.
+          no_output_timeout: 60m
 
   release:
     executor: node

--- a/interop.js
+++ b/interop.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+// Ideally this would be just a Shell script but Windows exists and I don't want
+// to force Windows users to install Shell and configure it to be used to run
+// npm scripts (and break their Windows only projects?).
+
+const { spawnSync } = require("child_process");
+
+const { status } = spawnSync(
+  "node",
+  [
+    "./bin/test-e2e-interop.js",
+    // This is the shared stuff used in all of our projects.
+    "--config",
+    "./public/interop/base-config.json",
+    // This is specific to this project.
+    "--project",
+    "vis-charts https://github.com/visjs/vis-charts.git",
+    "--project",
+    "vis-data https://github.com/visjs/vis-data.git",
+    "--project",
+    "vis-dev-utils ./vis-dev-utils-0.0.0-no-version.tgz",
+    "--project",
+    "vis-graph3d https://github.com/visjs/vis-graph3d.git",
+    "--project",
+    "vis-network https://github.com/visjs/vis-network.git",
+    "--project",
+    "vis-timeline https://github.com/visjs/vis-timeline.git",
+    "--project",
+    "vis-util https://github.com/visjs/vis-util.git",
+    // Any additional options passed from the command line (e.g. a fail command
+    // for debugging).
+    ...process.argv.slice(2),
+  ],
+  { stdio: "inherit" }
+);
+process.exitCode = status;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "postinstall": "opencollective postinstall || exit 0",
     "prepublishOnly": "npm run build",
     "test": "npm run test:unit && npm run test:interop",
-    "test:interop": "node ./bin/test-e2e-interop.js --config ./public/interop/base-config.json --local-project \"vis-dev-utils .\"",
+    "test:interop": "node interop.js",
     "test:interop:debug": "npm run test:interop -- --fail-command \"$SHELL\"",
     "test:unit": "mocha --exit",
     "watch": "rollup --watch --config rollup.config.js"

--- a/public/interop/base-config.json
+++ b/public/interop/base-config.json
@@ -1,21 +1,11 @@
 {
   "package-script": [
-    "clean! build! test!",
-    "vis-charts generate-examples-index!",
-    "vis-data lint!",
-    "vis-dev-utils lint!",
-    "vis-graph3d lint! generate-examples-index!",
-    "vis-network lint! generate-examples-index!",
-    "vis-timeline generate-examples-index!",
-    "vis-util lint!"
-  ],
-  "remote-project": [
-    "vis-charts https://github.com/visjs/vis-charts.git",
-    "vis-data https://github.com/visjs/vis-data.git",
-    "vis-dev-utils https://github.com/visjs/vis-dev-utils.git",
-    "vis-graph3d https://github.com/visjs/vis-graph3d.git",
-    "vis-network https://github.com/visjs/vis-network.git",
-    "vis-timeline https://github.com/visjs/vis-timeline.git",
-    "vis-util https://github.com/visjs/vis-util.git"
+    "vis-charts clean! build! test! generate-examples-index!",
+    "vis-data clean! lint! build! test!",
+    "vis-dev-utils clean! lint! build! test!",
+    "vis-graph3d clean! lint! build! test! generate-examples-index!",
+    "vis-network clean! lint! build! test! generate-examples-index!",
+    "vis-timeline clean! build! test! generate-examples-index!",
+    "vis-util clean! lint! build! test!"
   ]
 }

--- a/src/test-e2e-interop/cli.ts
+++ b/src/test-e2e-interop/cli.ts
@@ -13,14 +13,6 @@ const y = yargs
       'This command will be run in a shell (therefore commands like "$SHELL" will work) after failure to inspect the state.',
     type: "string",
   })
-  .option("local-project", {
-    array: true,
-    default: [] as string[],
-    demandOption: false,
-    describe:
-      'Projects to copy from local dirs. This has the same format as --remote-project ("package-name URL/path") and if the package names are the same it takes precedence over --remote-project.',
-    type: "string",
-  })
   .option("package-script", {
     array: true,
     default: ["clean?", "build!", "test!", "generate-examples-index?"],
@@ -29,12 +21,12 @@ const y = yargs
       'The package scripts to run with each package, either "script-name!" to fail or "script-name?" to skip if the script doesn\'t exist in given package. By default the script is used for all packages, if you want to use it only for one add package name: "package-name script-name!". Scripts are invoked sequentially and command line order is preserved.',
     type: "string",
   })
-  .option("remote-project", {
+  .option("project", {
     array: true,
     default: [] as string[],
     demandOption: false,
     describe:
-      'Projects to clone using Git. The format is "package-name URL/path".',
+      'Projects to clone using Git, copy from directory or install from tarball. The format is "package-name URL/path".',
     type: "string",
   })
   .option("tmp-dir", {

--- a/src/test-e2e-interop/index.ts
+++ b/src/test-e2e-interop/index.ts
@@ -4,8 +4,7 @@ import { ProjectPaths, PackageScript, test } from "./test";
 
 const argv = parseArguments();
 
-const rawProjectPathArg = [...argv["remote-project"], ...argv["local-project"]];
-const projectPaths: ProjectPaths = rawProjectPathArg
+const projectPaths: ProjectPaths = argv["project"]
   .map((raw): [string, string] => {
     const [name, path] = raw.split(" ", 2);
 
@@ -57,4 +56,11 @@ const tmpPath = argv["tmp-dir"] ? resolve(argv["tmp-dir"]) : undefined;
 
 const failCommand = argv["fail-command"];
 
-test({ failCommand, packageScripts, projectPaths, tmpPath });
+test({ failCommand, packageScripts, projectPaths, tmpPath }).catch(
+  (reason): void => {
+    console.error(reason);
+    if (process.exitCode === 0) {
+      process.exitCode = 1;
+    }
+  }
+);

--- a/src/test-e2e-interop/util.ts
+++ b/src/test-e2e-interop/util.ts
@@ -1,53 +1,129 @@
-import { SpawnSyncReturns, execSync, spawnSync } from "child_process";
+import { execSync, spawn } from "child_process";
+import { join } from "path";
+import { createWriteStream } from "fs-extra";
 
-export function logError(title: string, details?: string): void {
-  const wrappedDetails = details ? `\n${details}\n` : "";
-  console.error(`\n==> ${title}${wrappedDetails}\n`);
+export class ProjectState {
+  /**
+   * This will be resolved or rejected once all the tasks associated with this
+   * project finish.
+   */
+  public promise: Promise<void>;
+  /**
+   * Run this to mark the project as successfully finished.
+   */
+  public resolve!: () => void;
+  /**
+   * Run this to mark the project as failed.
+   */
+  public reject!: (reason: Error) => void;
+  /**
+   * Provide information about current state of the project.
+   */
+  public stage: string = "pending";
+
+  public constructor() {
+    this.promise = new Promise<void>((resolve, reject): void => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+}
+
+export function logError(title: string, details?: string | Error): void {
+  const wrappedDetails =
+    details != null
+      ? `\n${details instanceof Error ? details.message : details}`
+      : "";
+  process.stderr.write(`\n==> ${title}${wrappedDetails}\n`);
 }
 export function logInfo(title: string, details?: string): void {
-  const wrappedDetails = details ? `:\n${details}\n` : "";
-  console.info(`\n==> ${title}${wrappedDetails}\n`);
+  const wrappedDetails = details ? `:\n${details}` : "";
+  process.stdout.write(`\n==> ${title}${wrappedDetails}\n`);
 }
+
+export function execFail(cwd: string, failCommand?: string): void {
+  if (failCommand) {
+    execSync(failCommand, {
+      cwd,
+      encoding: "utf8",
+      env: { ...process.env, VIS_INTEROP: "1" },
+      stdio: "inherit",
+    });
+  }
+}
+
+export type Spawn = (options: SpawnOrTrhowArgs) => Promise<void>;
 
 export interface SpawnOrTrhowArgs {
   cmd: readonly string[];
+  cwd: string;
   failCommand?: string;
 }
-export function spawnThrow({
-  cmd,
-  failCommand,
-}: SpawnOrTrhowArgs): SpawnSyncReturns<string> {
-  logInfo("Running", cmd.map((word): string => JSON.stringify(word)).join(" "));
+export function createSpawner(logDir: string, getState: () => string[]): Spawn {
+  let nextId = 1;
 
-  const result = spawnSync(cmd[0], cmd.slice(1), {
-    env: {
-      ...process.env,
-      VIS_INTEROP: "1",
-    },
-    encoding: "utf8",
-    stdio: [0, 1, 2],
-  });
+  return function spawnThrow({ cmd, cwd, failCommand }): ReturnType<Spawn> {
+    const id = nextId++;
+    const getHeaderLines = (): string[] => [
+      "time: " + new Date().toISOString(),
+      "id: " + id + " ",
+      "cwd: " + cwd,
+      "cmd: " + cmd.map((word): string => JSON.stringify(word)).join(" "),
+      "states:",
+      ...getState(),
+    ];
+    const getLogMessage = (): string =>
+      getHeaderLines()
+        .map((line): string => "  " + line)
+        .join("\n");
 
-  if (result.error) {
-    throw result.error;
-  } else if (result.status !== 0) {
-    if (failCommand) {
-      execSync(failCommand, {
-        env: {
-          ...process.env,
-          VIS_INTEROP: "1",
-        },
-        encoding: "utf8",
-        stdio: [0, 1, 2],
+    logInfo("Start", getLogMessage());
+
+    return new Promise((resolve, reject): void => {
+      let failed = false;
+
+      const logStream = createWriteStream(
+        join(logDir, ("" + id).padStart(3, "0") + ".log"),
+        {
+          flags: "a",
+        }
+      );
+
+      logStream.write(getHeaderLines().join("\n") + "\n\n");
+
+      const child = spawn(cmd[0], cmd.slice(1), {
+        cwd,
+        env: { ...process.env, VIS_INTEROP: "1" },
+        stdio: "pipe",
       });
-    }
 
-    throw new Error(
-      `${cmd.map((word): string => `"${word}"`).join(" ")}: exited with ${
-        result.status
-      }.`
-    );
-  }
+      child.stdout.pipe(logStream);
+      child.stderr.pipe(logStream);
 
-  return result;
+      child.on("close", (code): void => {
+        if (failed || code !== 0) {
+          logError("Fail", getLogMessage());
+
+          execFail(cwd, failCommand);
+          reject(
+            new Error(
+              `${cmd
+                .map((word): string => `"${word}"`)
+                .join(" ")}: exited with ${code}.`
+            )
+          );
+        } else {
+          logInfo("Okay", getLogMessage());
+          resolve();
+        }
+      });
+      child.on("error", (error): void => {
+        logError("Fail", getLogMessage());
+        failed = true;
+
+        execFail(cwd, failCommand);
+        reject(error);
+      });
+    });
+  };
 }

--- a/tsconfig.declarations.json
+++ b/tsconfig.declarations.json
@@ -7,7 +7,7 @@
     "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "js/src",
-    "target": "es2015"
+    "target": "es2020"
   },
   "exclude": ["node_modules", "**/__tests__/*"],
   "include": ["@types", "src/module"]

--- a/tsconfig.internal.json
+++ b/tsconfig.internal.json
@@ -6,7 +6,7 @@
     "declarationDir": "lib",
     "declarationMap": true,
     "outDir": "lib",
-    "target": "es2015"
+    "target": "es2020"
   },
   "exclude": ["node_modules", "**/__tests__/*"],
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "baseUrl": ".",
     "declaration": false,
     "esModuleInterop": true,
-    "lib": ["es2019"],
+    "lib": ["es2020"],
     "module": "es2015",
     "moduleResolution": "node",
     "outDir": "js/src",


### PR DESCRIPTION
Parallelization took down about 4 minutes (from 45 to 41, yay!). This was a massive waste of time and with the advantage of hindsight it makes perfect sense, a lot of the stuff we run is already trying to get as much as it can from multicore systems so the utilization is already very high. Plus dependants can't start before their dependencies are done, this pretty much limits parallelization to running Network, Timeline and Graph3D in parallel and everything else in series anyway. I'm keeping it though, because it's a bit faster and since it's all based on promises now, the control flow is much nicer and easier to follow (the projects simply await the promises of their dependencies).

Bigger improvement is that it's now possible to use already built and packed project instead of building it from scratch. This took down about 6 minutes (from 41 to 35 minutes). This basically allows us to add `npm pack` into build step and chain interop after it (before this change we would run things like `npm run build` and `npm run test` once as a part of the standard CI and once more with the bit by bit identical code as a part of interop testing).

However all these times apply to Vis Dev Utils and we don't make that many changes here, it will be mostly Renovate dealing with this (if it turns out to clog the CI we can tell it to work when we sleep, something like 22:00 through 6:00 UTC?). It doesn't make much of a sense to build the dependencies of packages (e.g. Vis Util for Vis Network) or the sibling packages (Vis Graph3D for Vis Network), it only makes sense to build the dependants (e.g. Vis Charts for Vis Network). What this means is that Vis Dev Utils is the worst case scenario, Vis Util is faster, Vis Data even more and Vis Network took 3 minutes (Vis Charts doesn't have many tests at the moment, we should write some more to make sure our projects actually work with each other).