### PR TITLE
feat(ci-utils): add a command for CI stuff we use in multiple repos

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,23 +4,6 @@
 #
 version: 2.1
 
-commands:
-  install-deps-for-screenshot-taking:
-    description: Install headless Chromium dependencies
-    steps:
-      - run:
-          name: Install Headless Chromium dependencies
-          command: |
-            sudo apt-get install -yq \
-            ca-certificates fonts-liberation gconf-service libappindicator1 \
-            libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 libcairo2 libcups2 \
-            libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 \
-            libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 \
-            libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 \
-            libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 \
-            libxi6 libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget \
-            xdg-utils
-
 executors:
   node:
     docker:
@@ -81,7 +64,7 @@ jobs:
       - attach_workspace:
           at: .
 
-      - install-deps-for-screenshot-taking
+      - run: node ./bin/ci-utils.js install-dependencies-for chromium
 
       - run: npm run test:unit
 
@@ -92,7 +75,7 @@ jobs:
       - attach_workspace:
           at: .
 
-      - install-deps-for-screenshot-taking
+      - run: node ./bin/ci-utils.js install-dependencies-for chromium cypress
 
       - run:
           command: npm run test:interop

--- a/__snapshots__/test/package.test.ts.js
+++ b/__snapshots__/test/package.test.ts.js
@@ -7,6 +7,8 @@ exports['package exported files 1'] = {
     "        babel-preset/index.js",
     "        babel-register/index.js",
     "        babel-register/index.js.map",
+    "        bin/ci-utils.js",
+    "        bin/ci-utils.js.map",
     "        bin/generate-examples-index.js",
     "        bin/generate-examples-index.js.map",
     "        bin/test-e2e-interop.js",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "module": "dist/vis-dev-utils.esm.js",
   "types": "declarations",
   "bin": {
+    "ci-utils": "./bin/ci-utils.js",
     "generate-examples-index": "./bin/generate-examples-index.js",
     "test-e2e-interop": "./bin/test-e2e-interop.js"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -87,7 +87,7 @@ export default [
     };
   }),
   // Node commands.
-  ...["generate-examples-index", "test-e2e-interop"].map((name) => {
+  ...["generate-examples-index", "test-e2e-interop", "ci-utils"].map((name) => {
     return {
       input: `src/${name}`,
       output: {

--- a/src/ci-utils/index.ts
+++ b/src/ci-utils/index.ts
@@ -1,0 +1,52 @@
+import yargs from "yargs";
+import { spawnSync } from "child_process";
+
+yargs
+  .strict(true)
+  .usage("test-e2e-interop <command> [options]")
+  .hide("version")
+  .config()
+  .help()
+
+  .command(
+    "install-dependencies-for [tools..]",
+    "Install the dependencies for given tool(s). Note that this is specific to CircleCI's Debian based Docker images.",
+    (yargs) =>
+      yargs.positional("tools", {
+        choices: ["chromium", "cypress"],
+        demandOption: true,
+        describe: "The tool whose dependecies will be installed.",
+        type: "string",
+      }),
+    (argv): void => {
+      const dependecies = new Set<string>();
+
+      if (argv.tools.includes("chromium")) {
+        dependecies.add("libasound2");
+        dependecies.add("libgtk-3-0");
+        dependecies.add("libnss3");
+        dependecies.add("libxss1");
+        dependecies.add("libxtst6");
+      }
+
+      if (argv.tools.includes("cypress")) {
+        dependecies.add("libasound2");
+        dependecies.add("libgconf-2-4");
+        dependecies.add("libgtk-3-0");
+        dependecies.add("libgtk2.0-0");
+        dependecies.add("libnotify-dev");
+        dependecies.add("libnss3");
+        dependecies.add("libxss1");
+        dependecies.add("libxtst6");
+        dependecies.add("xauth");
+        dependecies.add("xvfb");
+      }
+
+      spawnSync("sudo", ["apt-get", "install", "-yq", ...dependecies], {
+        stdio: "inherit",
+      });
+    }
+  )
+
+  .parserConfiguration({ "camel-case-expansion": false })
+  .parse();


### PR DESCRIPTION
At the moment it's only for installing dependencies, but it's modular so adding anything new will be as simple as adding a new command to `src/ci-utils/index.ts`. This will come in handy especially if we decide to implement E2E interop tests (which seems doable to me if #272 gets merged) so that I won't have to copy paste the same `apt-install …` commands all over the place and also manually copy paste the same fix everywhere in case the dependencies change at some point (which is quite likely because CircleCI is rolling out “next-generation” Ubuntu based images with fewer preinstalled packages, they may discontinue the chunkier Debian based ones we've been using so far).

I also removed some dependencies that seem unnecessary (it runs just fine without them), I'm not sure anymore where I got the list originally, it probably lists a lot of dependencies that are installed anyway or maybe dependencies of dependencies, dependencies for functionality we don't use etc.

PS: CircleCI has orbs to achieve this. However I have no idea how to create an orb whereas this was easy for me to do, it's easy to use and CI provider agnostic, if we decide to switch at any point in the future.