### PR TITLE
fix(eslint-shareable-config): allow console.groupCollapsed

### DIFF
--- a/eslint-shareable-config/index.js
+++ b/eslint-shareable-config/index.js
@@ -56,7 +56,17 @@ module.exports = {
 
         "no-console": [
           "error",
-          { allow: ["debug", "error", "group", "groupEnd", "info", "warn"] },
+          {
+            allow: [
+              "debug",
+              "error",
+              "group",
+              "groupCollapsed",
+              "groupEnd",
+              "info",
+              "warn",
+            ],
+          },
         ],
       },
     },


### PR DESCRIPTION
Grouping is otherwise allowed already.