### PR TITLE
fix(puppeteer): replace the use of a deprecated method

### DIFF
--- a/src/generate-examples-index/content-builder/screenshots/index.ts
+++ b/src/generate-examples-index/content-builder/screenshots/index.ts
@@ -130,7 +130,7 @@ export async function generateScreenshot(
         "function fn() { return window.readyToTakeAScreenshot; }"
       );
     } else {
-      await page.waitFor(example.delay * 1000);
+      await page.waitForTimeout(example.delay * 1000);
     }
 
     const $element = await page.$(example.selector);


### PR DESCRIPTION
Nothing changes really, they just use different names instead of overloading based on argument type now.