### PR TITLE
fix(interop): don't log everything by default

### DIFF
--- a/src/test-e2e-interop/cli.ts
+++ b/src/test-e2e-interop/cli.ts
@@ -34,6 +34,12 @@ const y = yargs
     describe:
       "The working directory for E2E testing. If omitted a new tmp dir will be created and then disposed of.",
     type: "string",
+  })
+  .option("logs-to-stdout", {
+    demandOption: false,
+    default: false,
+    describe: "Output the logs to the stdout after the tests finished.",
+    type: "boolean",
   });
 
 /**

--- a/src/test-e2e-interop/index.ts
+++ b/src/test-e2e-interop/index.ts
@@ -56,7 +56,9 @@ const tmpPath = argv["tmp-dir"] ? resolve(argv["tmp-dir"]) : undefined;
 
 const failCommand = argv["fail-command"];
 
-test({ failCommand, packageScripts, projectPaths, tmpPath })
+const logsToStdout = argv["logs-to-stdout"];
+
+test({ failCommand, logsToStdout, packageScripts, projectPaths, tmpPath })
   .then((allSucceeded): void => {
     if (!allSucceeded) {
       process.exitCode = 1;

--- a/src/test-e2e-interop/test.ts
+++ b/src/test-e2e-interop/test.ts
@@ -266,19 +266,22 @@ async function checkTmpPath(data: TestData): Promise<void> {
 
 export interface TestArgs {
   failCommand?: string;
-  projectPaths: ProjectPaths;
+  logsToStdout?: boolean;
   packageScripts: readonly PackageScript[];
+  projectPaths: ProjectPaths;
   tmpPath?: string;
 }
 /**
  * @param root0
  * @param root0.failCommand
+ * @param root0.logsToStdout
  * @param root0.packageScripts
  * @param root0.projectPaths
  * @param root0.tmpPath
  */
 export async function test({
   failCommand,
+  logsToStdout,
   packageScripts,
   projectPaths,
   tmpPath,
@@ -420,21 +423,23 @@ export async function test({
     }
 
     // Print the detailed logs for inspection (especially in CI).
-    logInfo("Outputs");
-    process.stdout.write(
-      [
-        "",
-        ...(await Promise.all(
-          (
-            await readdir(data.tmpLogsResolve())
-          ).map(
-            (filename): Promise<string> =>
-              readFile(data.tmpLogsResolve(filename), "UTF-8")
-          )
-        )),
-        "",
-      ].join("\n\n" + ("-".repeat(80) + "\n").repeat(2) + "\n")
-    );
+    if (logsToStdout) {
+      logInfo("Outputs");
+      process.stdout.write(
+        [
+          "",
+          ...(await Promise.all(
+            (
+              await readdir(data.tmpLogsResolve())
+            ).map(
+              (filename): Promise<string> =>
+                readFile(data.tmpLogsResolve(filename), "UTF-8")
+            )
+          )),
+          "",
+        ].join("\n\n" + ("-".repeat(80) + "\n").repeat(2) + "\n")
+      );
+    }
 
     execFail(
       data.tmpDir.name,


### PR DESCRIPTION
There is a lot of output and it's better to get it as neater files in artifacts than a long and messy stdout.