### PR TITLE
fix(generate-rolup-configuration): add cjs and mjs extensions for plugin-babel

### DIFF
--- a/src/module/generate-rollup-configuration/index.ts
+++ b/src/module/generate-rollup-configuration/index.ts
@@ -400,7 +400,7 @@ const generateRollupPluginArray = (
             babelrc: false,
             configFile: false,
             exclude: BABEL_IGNORE_RE,
-            extensions: [".js", ".ts"],
+            extensions: [".js", ".ts", ".mjs", ".cjs"],
             presets: [["vis-dev-utils/babel-preset", { ts: true }]],
           }),
         ]


### PR DESCRIPTION
### Description

This commit fixes transpiling other vis libraries in standalone mode.

### Example

Here is an example for the vis-network package and targets, which doesn't support ES6 classes. This is also true for other Babel transformations.

**Before:**

```js
...
class SimpleDataPipe {
    _source;
    _transformers;
    _target;
...
```

**After:**

```js
...
var SimpleDataPipe = /*#__PURE__*/function () {
...
```