### PR TITLE
fix(generate-examples-index) <1> Globby can only handle POSIX paths

### DIFF
--- a/src/generate-examples-index/index.ts
+++ b/src/generate-examples-index/index.ts
@@ -2,7 +2,7 @@ import * as cheerio from "cheerio";
 import fs from "fs";
 import util from "util";
 import yargs from "yargs";
-import { join } from "path";
+import { posix } from "path";
 import { resolve } from "path";
 
 import {
@@ -165,7 +165,7 @@ function lintExample(path: string, page: cheerio.CheerioAPI): boolean {
     (
       await (
         await import("globby")
-      ).globby(join(pathsConfig.page.local, "**/*.html"))
+      ).globby(posix.join(pathsConfig.page.local, "**/*.html"))
     ).map(async (pagePath): Promise<any> => {
       const html = await readFile(pagePath, "utf-8");
       const $page = cheerio.load(html);


### PR DESCRIPTION
The `globby` package can only handle POSIX style paths, which means that it breaks on Windows when using `path.join()` instead of `path.posix.join()`.